### PR TITLE
Fix cross-drive path handling

### DIFF
--- a/src/srt_equalizer/srt_equalizer.py
+++ b/src/srt_equalizer/srt_equalizer.py
@@ -16,7 +16,15 @@ def validate_file_path(file_path: str, must_exist: bool = False) -> str:
     abs_path = os.path.abspath(os.path.normpath(file_path))
     
     # Security check for path traversal attempts
-    if os.path.relpath(abs_path).startswith('..'):
+    try:
+        relpath = os.path.relpath(abs_path)
+    except ValueError:
+        # On Windows os.path.relpath may raise a ValueError if the path is on
+        # a different drive than the current working directory.  In this case
+        # we skip the relative path check and treat the absolute path as safe.
+        relpath = abs_path
+
+    if relpath.startswith('..'):
         raise ValueError(f"Invalid path traversal attempt: {file_path}")
     
     if must_exist and not os.path.isfile(abs_path):

--- a/tests/test_srt_equalizer.py
+++ b/tests/test_srt_equalizer.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import pickle
 
 import pytest
@@ -17,6 +18,17 @@ def test_path_validation_security():
     # Test non-existent file handling
     with pytest.raises(FileNotFoundError):
         load_srt("non_existent.srt")
+
+
+def test_validate_file_path_cross_drive(monkeypatch):
+    """os.path.relpath may raise ValueError on Windows for different drives."""
+
+    def fake_relpath(path):
+        raise ValueError("path is on mount 'C:', start on mount 'D:'")
+
+    monkeypatch.setattr(os.path, "relpath", fake_relpath)
+    result = validate_file_path("tests/gwb.srt")
+    assert result == os.path.abspath("tests/gwb.srt")
     
 
 
@@ -112,3 +124,4 @@ def test_split_subtitle_punctuation():
 
     # check fragment timing
     assert s[2].end == sub.end
+


### PR DESCRIPTION
## Summary
- handle `ValueError` from `os.path.relpath` in `validate_file_path`
- test cross-drive path scenario

## Testing
- `pytest -q`